### PR TITLE
Fix failure on Windows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,15 +20,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: ${{ github.action_path }}/main.sh
-      if: runner.os != 'Windows'
-      shell: bash
-      env:
-        FILE_PATH: ${{ inputs.file_path }}
-        PROPERTY: ${{ inputs.property }}
-        VALUE: ${{ inputs.value }}
-    - run: bash ${{ github.action_path }}/main.sh
-      if: runner.os == 'Windows'
+    - run: bash $GITHUB_ACTION_PATH/main.sh
       shell: bash
       env:
         FILE_PATH: ${{ inputs.file_path }}

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         FILE_PATH: ${{ inputs.file_path }}
         PROPERTY: ${{ inputs.property }}
         VALUE: ${{ inputs.value }}
-    - run: bash main.sh
+    - run: bash ${{ github.action_path }}/main.sh
       if: runner.os == 'Windows'
       shell: bash
       env:


### PR DESCRIPTION
Use `$GITHUB_ACTION_PATH` instead of `${{ github.action_path }}` can solve the problem that backslashes aren’t escaped properly to be used in bash on Windows runner. (https://github.com/orgs/community/discussions/25910)